### PR TITLE
remove \n and \r after the authString is base 64 encoded. due to java bug

### DIFF
--- a/openid-connect-java-ppaccess/PPAccessClient.java
+++ b/openid-connect-java-ppaccess/PPAccessClient.java
@@ -195,7 +195,10 @@ public class PPAccessClient {
 
 		String authString = clientId + ":" + clientSecret;
 		BASE64Encoder encoder = new BASE64Encoder();
-		return encoder.encode(authString.getBytes());
+		String header = encoder.encode(authString.getBytes());
+		header = header.replace("\n", "");
+		header = header.replace("\r", "");
+		return header;
 	}
 
 	/**


### PR DESCRIPTION
This bug can be reproduced with java 6_16. 
