### PR TITLE
Update Copyright Holder

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,4 +1,4 @@
-Copyright 2012 eBay Inc
+Copyright 2012 PayPal
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/openid-connect-php-ppaccess/auth.php
+++ b/openid-connect-php-ppaccess/auth.php
@@ -1,6 +1,6 @@
 <?php
 /******************************************
-* Copyright 2012 eBay Inc
+* Copyright 2012 PayPal
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/openid-connect-php-ppaccess/example.php
+++ b/openid-connect-php-ppaccess/example.php
@@ -1,6 +1,6 @@
 <?php
 /******************************************
-* Copyright 2012 eBay Inc
+* Copyright 2012 PayPal
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/openid-connect-python-ppaccess/auth.py
+++ b/openid-connect-python-ppaccess/auth.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012 eBay Inc
+# Copyright 2012 PayPal
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/openid-connect-python-ppaccess/index.py
+++ b/openid-connect-python-ppaccess/index.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2012 eBay Inc
+# Copyright 2012 PayPal
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/openid-connect-ruby-ppaccess/access.rb
+++ b/openid-connect-ruby-ppaccess/access.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 eBay Inc
+# Copyright 2013 PayPal
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/openid-connect-ruby-ppaccess/example.rb
+++ b/openid-connect-ruby-ppaccess/example.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 eBay Inc
+# Copyright 2013 PayPal
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
As part of the split earlier this year, copyright for this project was assigned from the eBay Software Foundation to PayPal.

Fixes #12 
